### PR TITLE
read_stream options for adapters

### DIFF
--- a/lib/depot.ex
+++ b/lib/depot.ex
@@ -64,9 +64,42 @@ defmodule Depot do
     end
   end
 
-  def read_stream({adapter, config}, path, _opts \\ []) do
+  @doc """
+  Returns a `Stream` for reading the given `path`.
+
+  ## Options
+
+  The following stream options apply to all adapters:
+
+    * `:chunk_size` - When reading, the amount to read,
+      usually expressed as a number of bytes.
+
+  ## Examples
+
+  > Note: The shape of the returned stream will
+  > necessarily depend on the adapter in use. In the
+  > following examples the [`Local`](`Depot.Adapter.Local`)
+  > adapter is invoked, which returns a `File.Stream`.
+
+  ### Direct filesystem
+
+      filesystem = Depot.Adapter.Local.configure(prefix: "/home/user/storage")
+      {:ok, %File.Stream{}} = Depot.read_stream(filesystem, "test.txt")
+
+  ### Module-based filesystem
+
+      defmodule LocalFileSystem do
+        use Depot.Filesystem,
+          adapter: Depot.Adapter.Local,
+          prefix: "/home/user/storage"
+      end
+
+      {:ok, %File.Stream{}} = LocalFileSystem.read_stream("test.txt")
+
+  """
+  def read_stream({adapter, config}, path, opts \\ []) do
     with {:ok, path} <- Depot.RelativePath.normalize(path) do
-      adapter.read_stream(config, path)
+      adapter.read_stream(config, path, opts)
     end
   end
 

--- a/lib/depot/adapter.ex
+++ b/lib/depot/adapter.ex
@@ -3,13 +3,14 @@ defmodule Depot.Adapter do
   Behaviour for how `Depot` adapters work.
   """
   @type path :: Path.t()
+  @type stream_opts :: keyword
   @opaque config :: struct
 
   @callback starts_processes() :: boolean
   @callback configure(keyword) :: {module(), config}
   @callback write(config, path, contents :: iodata()) :: :ok | {:error, term}
   @callback read(config, path) :: {:ok, binary} | {:error, term}
-  @callback read_stream(config, path) :: {:ok, Enumerable.t()} | {:error, term}
+  @callback read_stream(config, path, stream_opts) :: {:ok, Enumerable.t()} | {:error, term}
   @callback delete(config, path) :: :ok | {:error, term}
   @callback move(config, source :: path, destination :: path) :: :ok | {:error, term}
   @callback copy(config, source :: path, destination :: path) :: :ok | {:error, term}

--- a/lib/depot/adapter/in_memory.ex
+++ b/lib/depot/adapter/in_memory.ex
@@ -69,6 +69,11 @@ defmodule Depot.Adapter.InMemory do
   end
 
   @impl Depot.Adapter
+  def read_stream(_config, _path, _opts) do
+    {:error, __MODULE__}
+  end
+
+  @impl Depot.Adapter
   def delete(%Config{} = config, path) do
     Agent.update(Depot.Registry.via(__MODULE__, config.name), fn state ->
       {_, state} = pop_in(state, accessor(path))

--- a/lib/depot/filesystem.ex
+++ b/lib/depot/filesystem.ex
@@ -4,6 +4,8 @@ defmodule Depot.Filesystem do
   """
   @callback write(path :: Path.t(), contents :: binary, opts :: keyword()) :: :ok | {:error, term}
   @callback read(path :: Path.t(), opts :: keyword()) :: {:ok, binary} | {:error, term}
+  @callback read_stream(path :: Path.t(), opts :: keyword()) ::
+              {:ok, Enumerable.t()} | {:error, term}
   @callback delete(path :: Path.t(), opts :: keyword()) :: :ok | {:error, term}
   @callback move(source :: Path.t(), destination :: Path.t(), opts :: keyword()) ::
               :ok | {:error, term}
@@ -47,7 +49,7 @@ defmodule Depot.Filesystem do
 
       @impl true
       def read_stream(path, opts \\ []),
-          do: Depot.read_stream(@filesystem, path, opts)
+        do: Depot.read_stream(@filesystem, path, opts)
 
       @impl true
       def delete(path, opts \\ []),

--- a/test/depot/adapter/in_memory_test.exs
+++ b/test/depot/adapter/in_memory_test.exs
@@ -46,6 +46,15 @@ defmodule Depot.Adapter.InMemoryTest do
 
       assert {:ok, "Hello World"} = Depot.Adapter.InMemory.read(config, "test.txt")
     end
+
+    test "stream not implemented", %{test: test} do
+      {_, config} = filesystem = Depot.Adapter.InMemory.configure(name: test)
+
+      start_supervised(filesystem)
+
+      assert {:error, Depot.Adapter.InMemory} =
+               Depot.Adapter.InMemory.read_stream(config, "test.txt", [])
+    end
   end
 
   describe "delete" do

--- a/test/depot/adapter/local_test.exs
+++ b/test/depot/adapter/local_test.exs
@@ -39,6 +39,30 @@ defmodule Depot.Adapter.LocalTest do
 
       assert {:ok, "Hello World"} = Depot.Adapter.Local.read(config, "test.txt")
     end
+
+    test "stream options", %{prefix: prefix} do
+      {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
+
+      assert {:ok, %File.Stream{line_or_bytes: :line, modes: [:raw, :read_ahead, :binary]}} =
+               Depot.Adapter.Local.read_stream(config, "test.txt", [])
+
+      assert {:ok, %File.Stream{line_or_bytes: 1_024, modes: [:raw, :read_ahead, :binary]}} =
+               Depot.Adapter.Local.read_stream(config, "test.txt", chunk_size: 1_024)
+
+      assert {:ok, %File.Stream{modes: [{:encoding, :utf8}, :binary]}} =
+               Depot.Adapter.Local.read_stream(config, "test.txt", modes: [encoding: :utf8])
+    end
+
+    test "stream success", %{prefix: prefix} do
+      {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
+
+      :ok = File.write(Path.join(prefix, "test.txt"), "Hello World")
+
+      assert {:ok, %File.Stream{} = stream} =
+               Depot.Adapter.Local.read_stream(config, "test.txt", [])
+
+      assert Enum.reduce(stream, "", &(&2 <> &1)) == "Hello World"
+    end
   end
 
   describe "delete" do


### PR DESCRIPTION
Hi @bucha!  Re: elixir-depot/depot#2, the API for read_stream/2 looks great!  What do you think about making it `read_stream/3`, since even the built-in local adapter has potential options?  That's what this PR does :)

